### PR TITLE
Don't display incorrect unit label on datetime x-axis

### DIFF
--- a/pyntpg/plot_tabs/plot_widget.py
+++ b/pyntpg/plot_tabs/plot_widget.py
@@ -64,8 +64,9 @@ def plot_lines(ax, lines):
             if key in line.keys():
                 once_per_axes.update({key: line.pop(key)})
 
-        # create axes labels "var [units]"
-        if "units" in yaxis.keys() and "variable" in yaxis.keys():
+        # create axes labels "var [units]", 
+        # except if it's a datetime x-axis so that we don't see [seconds since ...]
+        if "units" in yaxis.keys() and "variable" in yaxis.keys() and panel_type != "datetime":
             units = yaxis["units"]
             y_label[units] = y_label.get(units, []) + [yaxis["variable"]]
         if "units" in xaxis.keys() and "variable" in xaxis.keys():


### PR DESCRIPTION
Suggestion: The pyntpg time axes say 'time (seconds since 2000-01-01.....)', should be just time.

I'm actually just going to get rid of the label. It should be pretty clear that it's time... I hope.
